### PR TITLE
feature(admin): add ability to collapse filter sidebar

### DIFF
--- a/django/contrib/admin/static/admin/css/changelists.css
+++ b/django/contrib/admin/static/admin/css/changelists.css
@@ -133,10 +133,9 @@
 
 #changelist-filter {
     flex: 0 0 240px;
-    order: 1;
     background: var(--darkened-bg);
     border-left: none;
-    margin: 0 0 0 30px;
+    margin: 0;
 }
 
 @media (forced-colors: active) {

--- a/django/contrib/admin/static/admin/css/sidebar.css
+++ b/django/contrib/admin/static/admin/css/sidebar.css
@@ -4,16 +4,14 @@
     max-height: 100vh;
 }
 
-.toggle-nav-sidebar {
+.toggle-sidebar {
     z-index: 20;
-    left: 0;
     display: flex;
     align-items: center;
     justify-content: center;
     flex: 0 0 23px;
     width: 23px;
     border: 0;
-    border-right: 1px solid var(--hairline-color);
     background-color: var(--body-bg);
     cursor: pointer;
     font-size: 1.25rem;
@@ -21,13 +19,23 @@
     padding: 0;
 }
 
+#toggle-nav-sidebar {
+    left: 0;
+    border-right: 1px solid var(--hairline-color);
+}
+
+#toggle-filter-sidebar {
+    right: 0;
+    border-left: 1px solid var(--hairline-color);
+}
+
 [dir="rtl"] .toggle-nav-sidebar {
     border-left: 1px solid var(--hairline-color);
     border-right: 0;
 }
 
-.toggle-nav-sidebar:hover,
-.toggle-nav-sidebar:focus {
+.toggle-sidebar:hover,
+.toggle-sidebar:focus {
     background-color: var(--darkened-bg);
 }
 
@@ -51,24 +59,36 @@
     margin-right: -276px;
 }
 
-.toggle-nav-sidebar::before {
+#toggle-nav-sidebar::before,
+.main.changelist-filter-expanded #toggle-filter-sidebar::before {
+    /* arrow right */
     content: '\00BB';
 }
 
-.main.shifted .toggle-nav-sidebar::before {
+#toggle-filter-sidebar::before,
+.main.nav-sidebar-expanded #toggle-nav-sidebar::before {
+    /* arrow left */
     content: '\00AB';
+}
+
+.main > #changelist-filter {
+    display: none;
 }
 
 .main > #nav-sidebar {
     visibility: hidden;
 }
 
-.main.shifted > #nav-sidebar {
+.main.changelist-filter-expanded > #changelist-filter {
+    display: block;
+}
+
+.main.nav-sidebar-expanded > #nav-sidebar {
     margin-left: 0;
     visibility: visible;
 }
 
-[dir="rtl"] .main.shifted > #nav-sidebar {
+[dir="rtl"] .main.nav-sidebar-expanded > #nav-sidebar {
     margin-right: 0;
 }
 

--- a/django/contrib/admin/static/admin/js/nav_sidebar.js
+++ b/django/contrib/admin/static/admin/js/nav_sidebar.js
@@ -1,25 +1,25 @@
 'use strict';
 {
-    const toggleNavSidebar = document.getElementById('toggle-nav-sidebar');
-    if (toggleNavSidebar !== null) {
-        const navSidebar = document.getElementById('nav-sidebar');
-        const main = document.getElementById('main');
-        let navSidebarIsOpen = localStorage.getItem('django.admin.navSidebarIsOpen');
-        if (navSidebarIsOpen === null) {
-            navSidebarIsOpen = 'true';
+    function handleSidebarToggle(toggleElementId, sidebarID, storeProperty) {
+        const toggleNode = document.getElementById(toggleElementId);
+        if (toggleNode === null) {
+            return;
         }
-        main.classList.toggle('shifted', navSidebarIsOpen === 'true');
-        navSidebar.setAttribute('aria-expanded', navSidebarIsOpen);
 
-        toggleNavSidebar.addEventListener('click', function() {
-            if (navSidebarIsOpen === 'true') {
-                navSidebarIsOpen = 'false';
-            } else {
-                navSidebarIsOpen = 'true';
-            }
-            localStorage.setItem('django.admin.navSidebarIsOpen', navSidebarIsOpen);
-            main.classList.toggle('shifted');
-            navSidebar.setAttribute('aria-expanded', navSidebarIsOpen);
+        const toggleClass = `${sidebarID}-expanded`;
+        let sidebarIsOpen = localStorage.getItem(storeProperty) !== 'false';
+
+        const mainNode = document.getElementById('main');
+        mainNode.classList.toggle(toggleClass, sidebarIsOpen);
+
+        const sidebarNode = document.getElementById(sidebarID);
+        sidebarNode.setAttribute('aria-expanded', sidebarIsOpen);
+
+        toggleNode.addEventListener('click', function () {
+            sidebarIsOpen = !sidebarIsOpen;
+            localStorage.setItem(storeProperty, sidebarIsOpen);
+            mainNode.classList.toggle(toggleClass);
+            sidebarNode.setAttribute('aria-expanded', sidebarIsOpen);
         });
     }
 
@@ -76,4 +76,19 @@
     }
     window.initSidebarQuickFilter = initSidebarQuickFilter;
     initSidebarQuickFilter();
+
+    // right sidebar (filter)
+    handleSidebarToggle(
+        'toggle-filter-sidebar',
+        'changelist-filter',
+        'django.admin.filterSidebarIsOpen',
+    );
+
+    // left sidebar (nav)
+    handleSidebarToggle(
+        'toggle-nav-sidebar',
+        'nav-sidebar',
+        'django.admin.navSidebarIsOpen',
+    );
+
 }

--- a/django/contrib/admin/templates/admin/base.html
+++ b/django/contrib/admin/templates/admin/base.html
@@ -9,7 +9,7 @@
   <script src="{% static "admin/js/theme.js" %}" defer></script>
 {% endblock %}
 {% if not is_popup and is_nav_sidebar_enabled %}
-  <link rel="stylesheet" href="{% static "admin/css/nav_sidebar.css" %}">
+  <link rel="stylesheet" href="{% static "admin/css/sidebar.css" %}">
   <script src="{% static 'admin/js/nav_sidebar.js' %}" defer></script>
 {% endif %}
 {% block extrastyle %}{% endblock %}
@@ -110,6 +110,7 @@
         <!-- END Content -->
         {% block footer %}<div id="footer"></div>{% endblock %}
       </main>
+      {% block filters %}{% endblock %}
     </div>
 </div>
 <!-- END Container -->

--- a/django/contrib/admin/templates/admin/change_list.html
+++ b/django/contrib/admin/templates/admin/change_list.html
@@ -21,7 +21,9 @@
 {% block extrahead %}
 {{ block.super }}
 {{ media.js }}
-<script src="{% static 'admin/js/filters.js' %}" defer></script>
+{% if cl.has_filters %}
+  <script src="{% static 'admin/js/filters.js' %}" defer></script>
+{% endif %}
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}
@@ -71,23 +73,25 @@
         {% block pagination %}{% pagination cl %}{% endblock %}
         </form>
       </div>
-      {% block filters %}
-        {% if cl.has_filters %}
-          <nav id="changelist-filter" aria-labelledby="changelist-filter-header">
-            <h2 id="changelist-filter-header">{% translate 'Filter' %}</h2>
-            {% if cl.is_facets_optional or cl.has_active_filters %}<div id="changelist-filter-extra-actions">
-              {% if cl.is_facets_optional %}<h3>
-                {% if cl.add_facets %}<a href="{{ cl.remove_facet_link }}" class="hidelink">{% translate "Hide counts" %}</a>
-                {% else %}<a href="{{ cl.add_facet_link }}" class="viewlink">{% translate "Show counts" %}</a>{% endif %}
-              </h3>{% endif %}
-              {% if cl.has_active_filters %}<h3>
-                <a href="{{ cl.clear_all_filters_qs }}">&#10006; {% translate "Clear all filters" %}</a>
-              </h3>{% endif %}
-            </div>{% endif %}
-            {% for spec in cl.filter_specs %}{% admin_list_filter cl spec %}{% endfor %}
-          </nav>
-        {% endif %}
-      {% endblock %}
     </div>
   </div>
+{% endblock %}
+
+{% block filters %}
+  {% if cl.has_filters %}
+    <nav id="changelist-filter" class="module" aria-labelledby="changelist-filter-header">
+      <h2 id="changelist-filter-header">{% translate 'Filter' %}</h2>
+      {% if cl.is_facets_optional or cl.has_active_filters %}<div id="changelist-filter-extra-actions">
+        {% if cl.is_facets_optional %}<h3>
+          {% if cl.add_facets %}<a href="{{ cl.remove_facet_link }}" class="hidelink">{% translate "Hide counts" %}</a>
+          {% else %}<a href="{{ cl.add_facet_link }}" class="viewlink">{% translate "Show counts" %}</a>{% endif %}
+        </h3>{% endif %}
+        {% if cl.has_active_filters %}<h3>
+          <a href="{{ cl.clear_all_filters_qs }}">&#10006; {% translate "Clear all filters" %}</a>
+        </h3>{% endif %}
+      </div>{% endif %}
+      {% for spec in cl.filter_specs %}{% admin_list_filter cl spec %}{% endfor %}
+    </nav>
+    <button class="sticky toggle-sidebar sidebar-filter" id="toggle-filter-sidebar" aria-label="{% translate 'Toggle filters' %}"></button>
+  {% endif %}
 {% endblock %}

--- a/django/contrib/admin/templates/admin/nav_sidebar.html
+++ b/django/contrib/admin/templates/admin/nav_sidebar.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<button class="sticky toggle-nav-sidebar" id="toggle-nav-sidebar" aria-label="{% translate 'Toggle navigation' %}"></button>
+<button class="sticky toggle-sidebar" id="toggle-nav-sidebar" aria-label="{% translate 'Toggle navigation' %}"></button>
 <nav class="sticky" id="nav-sidebar" aria-label="{% translate 'Sidebar' %}">
   <input type="search" id="nav-filter"
          placeholder="{% translate 'Start typing to filter…' %}"


### PR DESCRIPTION
Reusing some parts of `nav-sidebar` without doing too much unnecessary changes in said element to keep the diff small.

before:
![before](https://github.com/reef-technologies/django/assets/135112713/0c89401e-a335-466d-9240-b81324f2903c)


after (expanded / collapsed):
![after](https://github.com/reef-technologies/django/assets/135112713/0bcd5b5c-24a9-425e-ada3-20a1814087e2)

